### PR TITLE
Restart game when pressing R

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,14 @@ window/size/viewport_width=1280
 window/size/viewport_height=720
 window/stretch/mode="viewport"
 
+[input]
+
+restart_game={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":0,"echo":false,"script":null)
+, null]
+}
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/scenes/game_manager/curtain.gd
+++ b/scenes/game_manager/curtain.gd
@@ -7,6 +7,9 @@ signal finished
 func play_animation() -> void:
 	$AnimationPlayer.play("next_level")
 
+func is_playing() -> bool:
+	return $AnimationPlayer.is_playing()
+
 func emit_change_scene_signal() -> void:
 	change_scene_now.emit()
 

--- a/scenes/game_manager/game_manager.gd
+++ b/scenes/game_manager/game_manager.gd
@@ -5,9 +5,19 @@ extends Node
 var levels: Array[PackedScene]
 var current_level_index: int = 0
 var current_level: Node
+var is_restarting: bool
 
 func _ready() -> void:
 	load_level(levels[0])
+	is_restarting = false
+
+func _input(event: InputEvent) -> void:
+	if not is_restarting and event.is_action_pressed("restart_game"):
+		is_restarting = true
+		if curtain.is_playing():
+			await curtain.finished
+		call_deferred("load_menu")
+		get_viewport().set_input_as_handled()
 
 func load_next_level() -> void:
 	current_level_index += 1

--- a/scenes/main_menu/start_menu.tscn
+++ b/scenes/main_menu/start_menu.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=18 format=3 uid="uid://bjipjl8dxe7mo"]
+[gd_scene load_steps=17 format=3 uid="uid://bjipjl8dxe7mo"]
 
 [ext_resource type="Script" path="res://scenes/main_menu/start_menu.gd" id="1_cqxbd"]
 [ext_resource type="PackedScene" uid="uid://bcnimij4eaggj" path="res://scenes/gameplay/levels/level_0.tscn" id="2_46ft8"]
-[ext_resource type="Texture2D" uid="uid://c73opf6qhieh3" path="res://assets/sprites/Portada.png" id="2_h4cya"]
 [ext_resource type="PackedScene" uid="uid://d1rlaax0lm88e" path="res://scenes/gameplay/levels/level_1.tscn" id="3_itduj"]
 [ext_resource type="Texture2D" uid="uid://bal8b8120hp3c" path="res://assets/sprites/rat-and-furious-logo.svg" id="3_pvrrl"]
 [ext_resource type="PackedScene" uid="uid://c0yp7mrfev6rc" path="res://scenes/gameplay/levels/level_2.tscn" id="4_nixmm"]
@@ -95,7 +94,7 @@ autoplay = "idle"
 [node name="Sprite2D" type="Sprite2D" parent="Level"]
 visible = false
 position = Vector2(640, 360)
-texture = ExtResource("2_h4cya")
+texture = ExtResource("3_pvrrl")
 metadata/_edit_lock_ = true
 
 [node name="Logo" type="Sprite2D" parent="Level"]


### PR DESCRIPTION
### Context
We had a common complain among players: it was annoying to wait for the timer to end when they made a mistake and knew in advance they couldn't finish the level with the time they had left. They would need to start over.

### Goal
Allow players to restart the game (as in, go back to the start menu) by pressing the `R` key.